### PR TITLE
Fix output product file extension in path template

### DIFF
--- a/configurations/fc/fc_ls8_2014_medoid.yaml
+++ b/configurations/fc/fc_ls8_2014_medoid.yaml
@@ -27,6 +27,7 @@ sources:
           nir_saturated: False
           swir1_saturated: False
           swir2_saturated: False
+          land_sea: land
 
 
 ## Define whether and how to chunk over time
@@ -58,22 +59,16 @@ storage:
 ## Computational
 computation:
   chunking:
-#    x: 400
-#    y: 800
     x: 2000
     y: 2000
 
 input_region:
-  tile: [-12, -18]
-#  from_file: /g/data/u46/users/dra547/test_stats_region/test_stats_region.shp
+  tile: [10, -40]
 
 ## Define statistics to perform and how to store the data
 output_products:
  - name: fc_medoid
    statistic: medoid_no_prov
-   file_path_template: 'LS8_2014_FC_MEDOID/{x}/LS_FC_MEDOID_3577_{name}_{x}_{y}_{epoch_start:%Y%m%d}_{epoch_end:%Y%m%d}.tiff'
+   file_path_template: 'LS8_2014_FC_MEDOID/{x}_{y}/LS_FC_MEDOID_3577_{name}_{x}_{y}_{epoch_start:%Y%m%d}_{epoch_end:%Y%m%d}.nc'
 #   description: Landsat 8 Fractional Cover 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)
    product_type: fractional_cover
-   output_params:
-     zlib: True
-     fletcher32: True


### PR DESCRIPTION
**Reason for this pull request**
Output product file name extension was using `.tiff` while storage driver was configured as `NetCDF CF`. 

**Proposed solution**
1) Fix output file name extension and directory structure

- [x] Tested this configuration on the test database